### PR TITLE
feat: Support plain text responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in apia-open_api.gemspec
 gemspec
 
-gem "apia", "~> 3.6"
+gem "apia", "~> 3.7"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in apia-open_api.gemspec
 gemspec
 
-gem "apia", "~> 3.5"
+gem "apia", "~> 3.6"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"

--- a/examples/core_api/base.rb
+++ b/examples/core_api/base.rb
@@ -3,6 +3,7 @@
 require "core_api/authenticators/main_authenticator"
 require "core_api/controllers/time_controller"
 require "core_api/endpoints/test_endpoint"
+require "core_api/endpoints/plain_text_endpoint"
 require "core_api/endpoints/legacy_endpoint"
 
 module CoreAPI
@@ -23,6 +24,8 @@ module CoreAPI
                                                                 endpoint: :format
       post "example/format", controller: Controllers::TimeController, endpoint: :format
       post "example/format_multiple", controller: Controllers::TimeController, endpoint: :format_multiple
+
+      get "plain_text", endpoint: Endpoints::PlainTextEndpoint
 
       group :time do
         name "Time functions"

--- a/examples/core_api/controllers/time_controller.rb
+++ b/examples/core_api/controllers/time_controller.rb
@@ -39,10 +39,8 @@ module CoreAPI
         field :formatted_times, type: [:string]
         field :times, type: [Objects::Time], include: "unix,year[as_string],as_array_of_objects[as_integer]"
         action do
-          times = []
-          request.arguments[:times].each do |time|
-            times << time.resolve
-          end
+          times = request.arguments[:times].map(&:resolve)
+
           response.add_field :formatted_times, times.map(&:to_s).join(", ")
           response.add_field :times, times
         end

--- a/examples/core_api/endpoints/plain_text_endpoint.rb
+++ b/examples/core_api/endpoints/plain_text_endpoint.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module CoreAPI
+  module Endpoints
+    class PlainTextEndpoint < Apia::Endpoint
+
+      description "Return a plain text response"
+      response_type Apia::Response::PLAIN
+
+      def call
+        response.body = "hello world!"
+      end
+
+    end
+  end
+end

--- a/lib/apia/open_api/objects/response.rb
+++ b/lib/apia/open_api/objects/response.rb
@@ -36,6 +36,7 @@ module Apia
           @route_spec = route_spec
           @api_authenticator = api_authenticator
           @http_status = @endpoint.definition.http_status
+          @response_type = @endpoint.definition.response_type
         end
 
         def add_to_spec
@@ -46,9 +47,14 @@ module Apia
         private
 
         def add_sucessful_response_schema
-          content_schema = {
-            properties: generate_properties_for_successful_response
-          }
+          if @response_type == Apia::Response::PLAIN
+            content_schema = { type: "string" }
+          else
+            content_schema = {
+              properties: generate_properties_for_successful_response
+            }
+          end
+
           required_fields = @endpoint.definition.fields.select { |_, field| field.condition.nil? }
           content_schema[:required] = required_fields.keys if required_fields.any?
 
@@ -56,7 +62,7 @@ module Apia
             "#{@http_status}": {
               description: @endpoint.definition.description || "",
               content: {
-                "application/json": {
+                @response_type => {
                   schema: content_schema
                 }
               }

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -198,6 +198,32 @@
         }
       }
     },
+    "/plain_text": {
+      "get": {
+        "operationId": "get:plain_text",
+        "tags": [
+          "Core"
+        ],
+        "parameters": [
+
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a plain text response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/APIAuthenticator403Response"
+          }
+        }
+      }
+    },
     "/time/now": {
       "get": {
         "operationId": "get:time_now",


### PR DESCRIPTION
Adds support for plain text responses (introduced in Apia 3.6, but didn't work with this library until 3.7)

Closes #63 