### PR TITLE
fix: ensure nested params don't break schema

### DIFF
--- a/examples/core_api/argument_sets/time_lookup_argument_set.rb
+++ b/examples/core_api/argument_sets/time_lookup_argument_set.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "object_lookup"
+
 module CoreAPI
   module ArgumentSets
     class TimeLookupArgumentSet < Apia::LookupArgumentSet
 
       argument :unix, type: :string, required: true
       argument :string, type: :string
+      argument :nested, type: ObjectLookup
 
       potential_error "InvalidTime" do
         code :invalid_time

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -82,6 +82,10 @@ module Apia
         # refer to: https://swagger.io/docs/specification/describing-parameters/#dependencies
         def generate_argument_set_params
           @argument.type.klass.definition.arguments.each_value do |child_arg|
+            # Complex argument sets are not supported in query params (e.g. nested objects)
+            # https://github.com/apiaframework/apia-openapi/issues/66
+            next if child_arg.type.argument_set?
+
             param = {
               name: "#{@argument.name}[#{child_arg.name}]",
               in: "query",

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -799,11 +799,27 @@
           },
           "string": {
             "type": "string"
+          },
+          "nested": {
+            "$ref": "#/components/schemas/ObjectLookup"
           }
         },
         "required": [
           "unix"
         ]
+      },
+      "ObjectLookup": {
+        "description": "All 'nested[]' params are mutually exclusive, only one can be provided.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "permalink": {
+            "type": "string",
+            "description": "The permalink of the object to look up"
+          }
+        }
       },
       "PostExampleFormatMultiple200ResponseTimes": {
         "type": "object",
@@ -1147,19 +1163,6 @@
         "enum": [
           "object_not_found"
         ]
-      },
-      "ObjectLookup": {
-        "description": "All 'object[]' params are mutually exclusive, only one can be provided.",
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "permalink": {
-            "type": "string",
-            "description": "The permalink of the object to look up"
-          }
-        }
       },
       "PostTestObject200ResponseTime": {
         "type": "object",


### PR DESCRIPTION
Currently the schema generation will throw an error if the Apia API declare nested query params.

Full details are explained in: https://github.com/apiaframework/apia-openapi/issues/66

This PR just omits nested params from the schema generation so that it can continue to generate.