### PR TITLE
fix: handle standard argument sets and array types for argument sets

### DIFF
--- a/examples/core_api/argument_sets/key_value.rb
+++ b/examples/core_api/argument_sets/key_value.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module CoreAPI
+  module ArgumentSets
+    class KeyValue < Apia::ArgumentSet
+
+      argument :key, type: :string, required: true
+      argument :value, type: :string
+
+    end
+  end
+end

--- a/examples/core_api/base.rb
+++ b/examples/core_api/base.rb
@@ -5,6 +5,7 @@ require "core_api/controllers/time_controller"
 require "core_api/endpoints/test_endpoint"
 require "core_api/endpoints/plain_text_endpoint"
 require "core_api/endpoints/legacy_endpoint"
+require "core_api/endpoints/paginated_endpoint"
 
 module CoreAPI
   class Base < Apia::API
@@ -26,6 +27,8 @@ module CoreAPI
       post "example/format_multiple", controller: Controllers::TimeController, endpoint: :format_multiple
 
       get "plain_text", endpoint: Endpoints::PlainTextEndpoint
+
+      get "paginated", endpoint: Endpoints::PaginatedEndpoint
 
       group :time do
         name "Time functions"

--- a/examples/core_api/endpoints/paginated_endpoint.rb
+++ b/examples/core_api/endpoints/paginated_endpoint.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CoreAPI
+  module Endpoints
+    class PaginatedEndpoint < Apia::Endpoint
+
+      name "Paginated Endpoint"
+      description "Returns a paginated list of strings"
+
+      field :names, type: [:string], paginate: true
+
+      def call
+        paginate :names, %w[Alice Bob Charlie David Eve Frank Grace Heidi]
+      end
+
+    end
+  end
+end

--- a/examples/core_api/endpoints/plain_text_endpoint.rb
+++ b/examples/core_api/endpoints/plain_text_endpoint.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
+require "core_api/argument_sets/key_value"
+
+
 module CoreAPI
   module Endpoints
     class PlainTextEndpoint < Apia::Endpoint
 
       name "Plain Text Endpoint"
       description "Return a plain text response"
+      argument :disk_template_options, [CoreAPI::ArgumentSets::KeyValue], required: false
+
+
       response_type Apia::Response::PLAIN
 
       def call

--- a/examples/core_api/endpoints/plain_text_endpoint.rb
+++ b/examples/core_api/endpoints/plain_text_endpoint.rb
@@ -2,7 +2,6 @@
 
 require "core_api/argument_sets/key_value"
 
-
 module CoreAPI
   module Endpoints
     class PlainTextEndpoint < Apia::Endpoint
@@ -10,7 +9,6 @@ module CoreAPI
       name "Plain Text Endpoint"
       description "Return a plain text response"
       argument :disk_template_options, [CoreAPI::ArgumentSets::KeyValue], required: false
-
 
       response_type Apia::Response::PLAIN
 

--- a/lib/apia/open_api/helpers.rb
+++ b/lib/apia/open_api/helpers.rb
@@ -52,6 +52,20 @@ module Apia
         schema
       end
 
+      def generate_array_schema(definition)
+        type = definition.type
+        schema = {
+          type: "array",
+          items: {
+            type: convert_type_to_open_api_data_type(type)
+          }
+        }
+        schema[:description] = definition.description if definition.description.present?
+        schema[:items][:format] = "float" if type.klass == Apia::Scalars::Decimal
+        schema[:items][:format] = "date" if type.klass == Apia::Scalars::Date
+        schema
+      end
+
       def generate_schema_ref(definition, id: nil, sibling_props: false, **schema_opts)
         id ||= generate_id_from_definition(definition.type.klass.definition)
         success = add_to_components_schemas(definition, id, **schema_opts)

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -69,6 +69,19 @@ module Apia
               schema: generate_scalar_schema(@argument)
             }
             param[:description] = @argument.description if @argument.description.present?
+
+            if param[:name] == "page"
+              param[:description] = "The page number to request. If not provided, the first page will be returned."
+              param[:schema][:default] = 1
+              param[:schema][:minimum] = 1
+            elsif param[:name] == "per_page"
+              param[:description] =
+                "The number of items to return per page. If not provided, the default value will be used."
+              param[:schema][:default] = 25
+              param[:schema][:minimum] = 1
+              param[:schema][:maximum] = 100
+            end
+
             param[:required] = true if @argument.required?
             add_to_parameters(param)
           end

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -70,16 +70,7 @@ module Apia
             }
             param[:description] = @argument.description if @argument.description.present?
 
-            if param[:name] == "page"
-              param[:description] = "The page number to request. If not provided, the first page will be returned."
-              param[:schema][:default] = 1
-              param[:schema][:minimum] = 1
-            elsif param[:name] == "per_page"
-              param[:description] =
-                "The number of items to return per page. If not provided, the default value will be used."
-              param[:schema][:default] = 25
-              param[:schema][:minimum] = 1
-            end
+            decorate_path_params(param)
 
             param[:required] = true if @argument.required?
             add_to_parameters(param)
@@ -87,6 +78,19 @@ module Apia
         end
 
         private
+
+        def decorate_path_params(param)
+          if param[:name] == "page"
+            param[:description] = "The page number to request. If not provided, the first page will be returned."
+            param[:schema][:default] = 1
+            param[:schema][:minimum] = 1
+          elsif param[:name] == "per_page"
+            param[:description] =
+              "The number of items to return per page. If not provided, the default value will be used."
+            param[:schema][:default] = 25
+            param[:schema][:minimum] = 1
+          end
+        end
 
         # Complex argument sets are not supported in query params (e.g. nested objects)
         # For any LookupArgumentSet only one argument is expected to be provided.

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -111,14 +111,16 @@ module Apia
             description << formatted_description(child_arg.description) if child_arg.description.present?
 
             if @argument.type.id.end_with?("Lookup")
-             description =  add_description_section(description, "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided.")
+              description = add_description_section(description,
+                                                    "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided.")
             end
 
             if @argument.array
               param[:name] = "#{@argument.name}[][#{child_arg.name}]"
               param[:schema] = generate_array_schema(child_arg)
 
-             description = add_description_section(description, "All `#{@argument.name}[]` params should have the same amount of elements.")
+              description = add_description_section(description,
+                                                    "All `#{@argument.name}[]` params should have the same amount of elements.")
             else
               param[:name] = "#{@argument.name}[#{child_arg.name}]"
               param[:schema] = generate_scalar_schema(child_arg)
@@ -134,7 +136,7 @@ module Apia
         # @param description [String] The current description of the parameter.
         # @param addition [String] The section to be added to the description.
         # @return [String] The updated description with the added section.
-        def add_description_section(description, addition) 
+        def add_description_section(description, addition)
           if description.present?
             description << "\n\n"
           end

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -111,18 +111,14 @@ module Apia
             description << formatted_description(child_arg.description) if child_arg.description.present?
 
             if @argument.type.id.end_with?("Lookup")
-
-              description << "\n\nAll '#{@argument.name}[]' params are mutually exclusive, only one can be provided."
-
-              # else
-              #   require "pry-remote"
-              #   binding.remote_pry
+             description =  add_description_section(description, "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided.")
             end
 
             if @argument.array
               param[:name] = "#{@argument.name}[][#{child_arg.name}]"
               param[:schema] = generate_array_schema(child_arg)
-              description << "\n\nAll `#{@argument.name}[]` params should have the same amount of elements."
+
+             description = add_description_section(description, "All `#{@argument.name}[]` params should have the same amount of elements.")
             else
               param[:name] = "#{@argument.name}[#{child_arg.name}]"
               param[:schema] = generate_scalar_schema(child_arg)
@@ -131,6 +127,19 @@ module Apia
             param[:description] = description.join(" ")
             add_to_parameters(param)
           end
+        end
+
+        # Adds a section to the description of a parameter.
+        #
+        # @param description [String] The current description of the parameter.
+        # @param addition [String] The section to be added to the description.
+        # @return [String] The updated description with the added section.
+        def add_description_section(description, addition) 
+          if description.present?
+            description << "\n\n"
+          end
+
+          description << addition
         end
 
         def add_to_parameters(param)

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -110,17 +110,17 @@ module Apia
             description << formatted_description(@argument.description) if @argument.description.present?
             description << formatted_description(child_arg.description) if child_arg.description.present?
 
-            if @argument.type.id.end_with?("Lookup")
-              description = add_description_section(description,
-                                                    "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided.")
-            end
+            add_lookup_description(description)
 
             if @argument.array
               param[:name] = "#{@argument.name}[][#{child_arg.name}]"
               param[:schema] = generate_array_schema(child_arg)
 
-              description = add_description_section(description,
-                                                    "All `#{@argument.name}[]` params should have the same amount of elements.")
+              add_description_section(
+                description,
+                "All `#{@argument.name}[]` params should have the same amount of elements."
+              )
+
             else
               param[:name] = "#{@argument.name}[#{child_arg.name}]"
               param[:schema] = generate_scalar_schema(child_arg)
@@ -132,16 +132,24 @@ module Apia
         end
 
         # Adds a section to the description of a parameter.
+        # If the description is not empty, a blank line is added before the section.
         #
         # @param description [String] The current description of the parameter.
         # @param addition [String] The section to be added to the description.
         # @return [String] The updated description with the added section.
         def add_description_section(description, addition)
-          if description.present?
+          unless description.empty?
             description << "\n\n"
           end
 
           description << addition
+        end
+
+        def add_lookup_description(description)
+          add_description_section(
+            description,
+            "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided."
+          )
         end
 
         def add_to_parameters(param)

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -87,7 +87,7 @@ module Apia
           elsif param[:name] == "per_page"
             param[:description] =
               "The number of items to return per page. If not provided, the default value will be used."
-            param[:schema][:default] = 25
+            param[:schema][:default] = 30
             param[:schema][:minimum] = 1
           end
         end

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -70,7 +70,7 @@ module Apia
             }
             param[:description] = @argument.description if @argument.description.present?
 
-            decorate_path_params(param)
+            add_pagination_params(param)
 
             param[:required] = true if @argument.required?
             add_to_parameters(param)
@@ -79,7 +79,7 @@ module Apia
 
         private
 
-        def decorate_path_params(param)
+        def add_pagination_params(param)
           if param[:name] == "page"
             param[:description] = "The page number to request. If not provided, the first page will be returned."
             param[:schema][:default] = 1

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -87,14 +87,31 @@ module Apia
             next if child_arg.type.argument_set?
 
             param = {
-              name: "#{@argument.name}[#{child_arg.name}]",
-              in: "query",
-              schema: generate_scalar_schema(child_arg)
+              in: "query"
             }
+
             description = []
             description << formatted_description(@argument.description) if @argument.description.present?
             description << formatted_description(child_arg.description) if child_arg.description.present?
-            description << "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided."
+
+            if @argument.type.id.end_with?("Lookup")
+
+              description << "\n\nAll '#{@argument.name}[]' params are mutually exclusive, only one can be provided."
+
+              # else
+              #   require "pry-remote"
+              #   binding.remote_pry
+            end
+
+            if @argument.array
+              param[:name] = "#{@argument.name}[][#{child_arg.name}]"
+              param[:schema] = generate_array_schema(child_arg)
+              description << "\n\nAll `#{@argument.name}[]` params should have the same amount of elements."
+            else
+              param[:name] = "#{@argument.name}[#{child_arg.name}]"
+              param[:schema] = generate_scalar_schema(child_arg)
+            end
+
             param[:description] = description.join(" ")
             add_to_parameters(param)
           end

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -87,7 +87,7 @@ module Apia
           elsif param[:name] == "per_page"
             param[:description] =
               "The number of items to return per page. If not provided, the default value will be used."
-            param[:schema][:default] = 30
+            param[:schema][:default] = @argument.default
             param[:schema][:minimum] = 1
           end
         end

--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -79,7 +79,6 @@ module Apia
                 "The number of items to return per page. If not provided, the default value will be used."
               param[:schema][:default] = 25
               param[:schema][:minimum] = 1
-              param[:schema][:maximum] = 100
             end
 
             param[:required] = true if @argument.required?

--- a/lib/apia/open_api/objects/path.rb
+++ b/lib/apia/open_api/objects/path.rb
@@ -162,6 +162,15 @@ module Apia
           current_group = group
 
           while current_group
+            # Add tags to the spec global tags if they don't already exist
+            # Include a description if the group has one.
+            unless @spec[:tags].any? { |t| t[:name] == current_group.name }
+              global_tag = { name: current_group.name }
+              global_tag[:description] = current_group.description if current_group.description
+              @spec[:tags] << global_tag
+
+            end
+
             tags.unshift(current_group.name)
             current_group = current_group.parent
           end

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -119,14 +119,10 @@ module Apia
       def add_tag_groups
         @spec[:paths].each_value do |methods|
           methods.each_value do |method_spec|
-            method_spec[:tags].each_with_index do |tag, tag_index|
-              unless @spec[:tags].any? { |t| t[:name] == tag }
-                @spec[:tags] << { name: tag }
-              end
+            tags = method_spec[:tags]
 
+            tags.each_with_index do |tag, tag_index|
               next if tag_index.zero?
-
-              tags = method_spec[:tags]
 
               parent_tag = tags[tag_index - 1]
               parent_index = get_tag_group_index(parent_tag)
@@ -140,6 +136,10 @@ module Apia
                 @spec[:"x-tagGroups"][parent_index][:tags] << tag
               end
             end
+
+            # Set the last tag as the tag for the method
+            # After we have built the tag group.
+            method_spec[:tags] = [tags.last] if tags.any?
           end
         end
 

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -26,7 +26,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set."
+            "description": "Time is a lookup argument set. \n\n All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "in": "query",
@@ -34,7 +34,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set."
+            "description": "Time is a lookup argument set. \n\n All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "timezone",
@@ -222,7 +222,7 @@
                 "type": "string"
               }
             },
-            "description": "All `disk_template_options[]` params should have the same amount of elements."
+            "description": "All 'disk_template_options[]' params are mutually exclusive, only one can be provided. \n\n All `disk_template_options[]` params should have the same amount of elements."
           },
           {
             "in": "query",
@@ -233,7 +233,7 @@
                 "type": "string"
               }
             },
-            "description": "All `disk_template_options[]` params should have the same amount of elements."
+            "description": "All 'disk_template_options[]' params are mutually exclusive, only one can be provided. \n\n All `disk_template_options[]` params should have the same amount of elements."
           }
         ],
         "responses": {
@@ -268,7 +268,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set."
+            "description": "Time is a lookup argument set. \n\n All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "in": "query",
@@ -276,7 +276,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set."
+            "description": "Time is a lookup argument set. \n\n All 'time[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "timezone",

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -253,6 +253,67 @@
         }
       }
     },
+    "/paginated": {
+      "get": {
+        "operationId": "get:paginated",
+        "summary": "Paginated Endpoint",
+        "description": "Returns a paginated list of strings",
+        "tags": [
+          "Core"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1
+            },
+            "description": "The page number to request. If not provided, the first page will be returned."
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 30,
+              "minimum": 1
+            },
+            "description": "The number of items to return per page. If not provided, the default value will be used."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a paginated list of strings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationObject"
+                    },
+                    "names": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "pagination",
+                    "names"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/APIAuthenticator403Response"
+          }
+        }
+      }
+    },
     "/time/formatting/incredibly/super/duper/long/format": {
       "get": {
         "operationId": "get:t_f_i_s_d_l_f",
@@ -897,6 +958,33 @@
         "properties": {
           "as_integer": {
             "type": "integer"
+          }
+        }
+      },
+      "PaginationObject": {
+        "type": "object",
+        "properties": {
+          "current_page": {
+            "type": "integer",
+            "description": "The current page"
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages",
+            "nullable": true
+          },
+          "total": {
+            "type": "integer",
+            "description": "The total number of items across all pages",
+            "nullable": true
+          },
+          "per_page": {
+            "type": "integer",
+            "description": "The number of items per page"
+          },
+          "large_set": {
+            "type": "boolean",
+            "description": "Is this a large set and therefore the total number of records cannot be returned?"
           }
         }
       },

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -21,20 +21,20 @@
         ],
         "parameters": [
           {
-            "name": "time[unix]",
             "in": "query",
+            "name": "time[unix]",
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set. All 'time[]' params are mutually exclusive, only one can be provided."
+            "description": "Time is a lookup argument set."
           },
           {
-            "name": "time[string]",
             "in": "query",
+            "name": "time[string]",
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set. All 'time[]' params are mutually exclusive, only one can be provided."
+            "description": "Time is a lookup argument set."
           },
           {
             "name": "timezone",
@@ -453,21 +453,21 @@
         ],
         "parameters": [
           {
-            "name": "object[id]",
             "in": "query",
+            "name": "object[id]",
             "schema": {
               "type": "string"
             },
-            "description": "All 'object[]' params are mutually exclusive, only one can be provided."
+            "description": "\n\nAll 'object[]' params are mutually exclusive, only one can be provided."
           },
           {
-            "name": "object[permalink]",
             "in": "query",
+            "name": "object[permalink]",
             "schema": {
               "type": "string",
               "description": "The permalink of the object to look up"
             },
-            "description": "The permalink of the object to look up. All 'object[]' params are mutually exclusive, only one can be provided."
+            "description": "The permalink of the object to look up. \n\nAll 'object[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "scalar",
@@ -594,20 +594,20 @@
         ],
         "parameters": [
           {
-            "name": "time[unix]",
             "in": "query",
+            "name": "time[unix]",
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set. All 'time[]' params are mutually exclusive, only one can be provided."
+            "description": "Time is a lookup argument set."
           },
           {
-            "name": "time[string]",
             "in": "query",
+            "name": "time[string]",
             "schema": {
               "type": "string"
             },
-            "description": "Time is a lookup argument set. All 'time[]' params are mutually exclusive, only one can be provided."
+            "description": "Time is a lookup argument set."
           },
           {
             "name": "timezone",

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -232,6 +232,132 @@
         }
       }
     },
+    "/time/formatting/incredibly/super/duper/long/format": {
+      "get": {
+        "operationId": "get:t_f_i_s_d_l_f",
+        "summary": "Format Time",
+        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n",
+        "tags": [
+          "Formatting"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "time[unix]",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Time is a lookup argument set."
+          },
+          {
+            "in": "query",
+            "name": "time[string]",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Time is a lookup argument set."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/TimeZone"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Format the given time",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "formatted_time": {
+                      "type": "string",
+                      "description": "Time formatted time as a string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "formatted_time"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidTimeResponse"
+          },
+          "403": {
+            "$ref": "#/components/responses/APIAuthenticator403Response"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitReachedResponse"
+          }
+        }
+      }
+    },
+    "/time/formatting/format": {
+      "post": {
+        "operationId": "post:time_formatting_format",
+        "summary": "Format Time",
+        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n",
+        "tags": [
+          "Formatting"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "time": {
+                    "$ref": "#/components/schemas/TimeLookupArgumentSet"
+                  },
+                  "timezone": {
+                    "$ref": "#/components/schemas/TimeZone"
+                  }
+                },
+                "required": [
+                  "time",
+                  "timezone"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Format the given time",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "formatted_time": {
+                      "type": "string",
+                      "description": "Time formatted time as a string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "formatted_time"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/InvalidTimeResponse"
+          },
+          "403": {
+            "$ref": "#/components/responses/APIAuthenticator403Response"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitReachedResponse"
+          }
+        }
+      }
+    },
     "/time/now": {
       "get": {
         "operationId": "get:time_now",
@@ -579,134 +705,6 @@
           },
           "404": {
             "$ref": "#/components/responses/ObjectNotFoundResponse"
-          }
-        }
-      }
-    },
-    "/time/formatting/incredibly/super/duper/long/format": {
-      "get": {
-        "operationId": "get:t_f_i_s_d_l_f",
-        "summary": "Format Time",
-        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n",
-        "tags": [
-          "Time functions",
-          "Formatting"
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "time[unix]",
-            "schema": {
-              "type": "string"
-            },
-            "description": "Time is a lookup argument set."
-          },
-          {
-            "in": "query",
-            "name": "time[string]",
-            "schema": {
-              "type": "string"
-            },
-            "description": "Time is a lookup argument set."
-          },
-          {
-            "name": "timezone",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/TimeZone"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Format the given time",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "formatted_time": {
-                      "type": "string",
-                      "description": "Time formatted time as a string",
-                      "nullable": true
-                    }
-                  },
-                  "required": [
-                    "formatted_time"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/InvalidTimeResponse"
-          },
-          "403": {
-            "$ref": "#/components/responses/APIAuthenticator403Response"
-          },
-          "429": {
-            "$ref": "#/components/responses/RateLimitReachedResponse"
-          }
-        }
-      }
-    },
-    "/time/formatting/format": {
-      "post": {
-        "operationId": "post:time_formatting_format",
-        "summary": "Format Time",
-        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n",
-        "tags": [
-          "Time functions",
-          "Formatting"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "time": {
-                    "$ref": "#/components/schemas/TimeLookupArgumentSet"
-                  },
-                  "timezone": {
-                    "$ref": "#/components/schemas/TimeZone"
-                  }
-                },
-                "required": [
-                  "time",
-                  "timezone"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Format the given time",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "formatted_time": {
-                      "type": "string",
-                      "description": "Time formatted time as a string",
-                      "nullable": true
-                    }
-                  },
-                  "required": [
-                    "formatted_time"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/InvalidTimeResponse"
-          },
-          "403": {
-            "$ref": "#/components/responses/APIAuthenticator403Response"
-          },
-          "429": {
-            "$ref": "#/components/responses/RateLimitReachedResponse"
           }
         }
       }
@@ -1337,22 +1335,14 @@
   ],
   "tags": [
     {
-      "name": "Core"
-    },
-    {
-      "name": "Time functions"
+      "name": "Time functions",
+      "description": "Everything related to time elements"
     },
     {
       "name": "Formatting"
     }
   ],
   "x-tagGroups": [
-    {
-      "name": "Core",
-      "tags": [
-        "Core"
-      ]
-    },
     {
       "name": "Time functions",
       "tags": [

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -213,7 +213,28 @@
           "Core"
         ],
         "parameters": [
-
+          {
+            "in": "query",
+            "name": "disk_template_options[][key]",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "All `disk_template_options[]` params should have the same amount of elements."
+          },
+          {
+            "in": "query",
+            "name": "disk_template_options[][value]",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "All `disk_template_options[]` params should have the same amount of elements."
+          }
         ],
         "responses": {
           "200": {
@@ -584,7 +605,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "\n\nAll 'object[]' params are mutually exclusive, only one can be provided."
+            "description": "All 'object[]' params are mutually exclusive, only one can be provided."
           },
           {
             "in": "query",
@@ -593,7 +614,7 @@
               "type": "string",
               "description": "The permalink of the object to look up"
             },
-            "description": "The permalink of the object to look up. \n\nAll 'object[]' params are mutually exclusive, only one can be provided."
+            "description": "The permalink of the object to look up. \n\n All 'object[]' params are mutually exclusive, only one can be provided."
           },
           {
             "name": "scalar",


### PR DESCRIPTION
## Main Fixes
- Only add the mutually exclusive information to the parameter description if the argument set is a lookup argument set
- Properly handle argument sets that are arrays.
## Additional fixes:
- Global Tags are generated at the same time as endpoint tags. Allowing us to add descriptions to them if the group has a description.
- After building tagGroups endpoints will now have their tags set to the single most specific tag. (this is because multiple tags is discouraged.)
- `page`: 
	- `description`  :The page number to request. If not provided, the first page will be returned.
	-  `default` : 1
	-  `minimum` : 1
- `per_page`:
	- `description`: The number of items to return per page. If not provided, the default value will be used.
	- `default`: 30
	- `minimum`: 1