### PR TITLE
feat: allow passing of info + external_docs to the openapi specification.

### DIFF
--- a/examples/config.ru
+++ b/examples/config.ru
@@ -24,10 +24,7 @@ use Apia::OpenApi::Rack,
     base_url: "http://127.0.0.1:9292/core/v1/",
     info: {
       version: "2.1.3",
-      externalDocs: {
-        description: "Find out more",
-        url: "https://example.com"
-      },
+
       contact: {
         name: "API Support",
         email: "support@example.com",
@@ -39,6 +36,10 @@ use Apia::OpenApi::Rack,
       },
       termsOfService: "https://example.com/terms",
       "x-added-info": "This is an example of adding custom information to the OpenAPI spec"
+    },
+    external_docs: {
+        description: "Find out more",
+        url: "https://example.com"
     }
 use Apia::Rack, CoreAPI::Base, "/core/v1", development: true
 

--- a/examples/config.ru
+++ b/examples/config.ru
@@ -21,7 +21,25 @@ require "core_api/base"
 use Apia::OpenApi::Rack,
     api_class: "CoreAPI::Base",
     schema_path: "/core/v1/schema/openapi.json",
-    base_url: "http://127.0.0.1:9292/core/v1/"
+    base_url: "http://127.0.0.1:9292/core/v1/",
+    info: {
+      version: "2.1.3",
+      externalDocs: {
+        description: "Find out more",
+        url: "https://example.com"
+      },
+      contact: {
+        name: "API Support",
+        email: "support@example.com",
+        url: "https://example.com/support"
+      },
+      license: {
+        name: "Apache 2.0",
+        url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+      },
+      termsOfService: "https://example.com/terms",
+      "x-added-info": "This is an example of adding custom information to the OpenAPI spec"
+    }
 use Apia::Rack, CoreAPI::Base, "/core/v1", development: true
 
 app = proc do

--- a/examples/config.ru
+++ b/examples/config.ru
@@ -38,8 +38,8 @@ use Apia::OpenApi::Rack,
       "x-added-info": "This is an example of adding custom information to the OpenAPI spec"
     },
     external_docs: {
-        description: "Find out more",
-        url: "https://example.com"
+      description: "Find out more",
+      url: "https://example.com"
     }
 use Apia::Rack, CoreAPI::Base, "/core/v1", development: true
 

--- a/lib/apia/open_api/rack.rb
+++ b/lib/apia/open_api/rack.rb
@@ -29,6 +29,10 @@ module Apia
         @options[:base_url] || "https://api.example.com/api/v1"
       end
 
+      def info
+        @options[:info] || {}
+      end
+
       def call(env)
         if @options[:hosts]&.none? { |host| host == env["HTTP_HOST"] }
           return @app.call(env)
@@ -38,7 +42,7 @@ module Apia
           return @app.call(env)
         end
 
-        specification = Specification.new(api_class, base_url, @options[:name])
+        specification = Specification.new(api_class, base_url, @options[:name], info)
         body = specification.json
 
         [200, { "content-type" => "application/json", "content-length" => body.bytesize.to_s }, [body]]

--- a/lib/apia/open_api/rack.rb
+++ b/lib/apia/open_api/rack.rb
@@ -29,6 +29,10 @@ module Apia
         @options[:base_url] || "https://api.example.com/api/v1"
       end
 
+      def external_docs
+        @options[:external_docs] || {}
+      end
+
       def info
         @options[:info] || {}
       end
@@ -42,7 +46,7 @@ module Apia
           return @app.call(env)
         end
 
-        specification = Specification.new(api_class, base_url, @options[:name], info)
+        specification = Specification.new(api_class, base_url, @options[:name], info, external_docs)
         body = specification.json
 
         [200, { "content-type" => "application/json", "content-length" => body.bytesize.to_s }, [body]]

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -21,6 +21,7 @@ module Apia
         @spec = {
           openapi: OPEN_API_VERSION,
           info: info,
+          externalDocs: external_docs,
           servers: [],
           paths: {},
           components: {
@@ -31,8 +32,8 @@ module Apia
           "x-tagGroups": []
         }
 
-        if external_docs.any?
-          @spec[:externalDocs] = external_docs
+        if @spec[:externalDocs].nil? || @spec[:externalDocs].empty?
+          @spec.delete(:externalDocs)
         end
 
         # path_ids is used to keep track of all the IDs of all the paths we've generated, to avoid duplicates

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -14,13 +14,14 @@ module Apia
 
       OPEN_API_VERSION = "3.0.0" # The Ruby client generator currently only supports v3.0.0 https://openapi-generator.tech/
 
-      def initialize(api, base_url, name, info = {})
+      def initialize(api, base_url, name, info = {}, external_docs = {})
         @api = api
         @base_url = base_url
         @name = name || "Core" # will be suffixed with 'Api' and used in the client generator
         @spec = {
           openapi: OPEN_API_VERSION,
           info: info,
+          externalDocs: external_docs,
           servers: [],
           paths: {},
           components: {

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -21,7 +21,6 @@ module Apia
         @spec = {
           openapi: OPEN_API_VERSION,
           info: info,
-          externalDocs: external_docs,
           servers: [],
           paths: {},
           components: {
@@ -31,6 +30,10 @@ module Apia
           tags: [],
           "x-tagGroups": []
         }
+
+        if external_docs.any?
+          @spec[:externalDocs] = external_docs
+        end
 
         # path_ids is used to keep track of all the IDs of all the paths we've generated, to avoid duplicates
         # refer to the Path object for more info

--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -14,13 +14,13 @@ module Apia
 
       OPEN_API_VERSION = "3.0.0" # The Ruby client generator currently only supports v3.0.0 https://openapi-generator.tech/
 
-      def initialize(api, base_url, name)
+      def initialize(api, base_url, name, info = {})
         @api = api
         @base_url = base_url
         @name = name || "Core" # will be suffixed with 'Api' and used in the client generator
         @spec = {
           openapi: OPEN_API_VERSION,
-          info: {},
+          info: info,
           servers: [],
           paths: {},
           components: {
@@ -61,11 +61,13 @@ module Apia
 
       def add_info
         title = @api.definition.name || @api.definition.id
-        @spec[:info] = {
-          version: "1.0.0",
-          title: title
-        }
-        @spec[:info][:description] = @api.definition.description || "Welcome to the documentation for the #{title}"
+        @spec[:info][:version] = "1.0.0" if @spec[:info][:version].nil?
+        @spec[:info][:title] = title if @spec[:info][:title].nil?
+
+        return unless @spec[:info][:description].nil?
+
+        @spec[:info][:description] =
+          @api.definition.description || "Welcome to the documentation for the #{title}"
       end
 
       def add_servers

--- a/spec/apia/open_api/rack_spec.rb
+++ b/spec/apia/open_api/rack_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Apia::OpenApi::Rack do
         )
 
         expect(Apia::OpenApi::Specification).to have_received(:new).with(
-          MockApi, default_base_url, name_option
+          MockApi, default_base_url, name_option, {}, {}
         )
       end
 
@@ -80,7 +80,7 @@ RSpec.describe Apia::OpenApi::Rack do
           middleware_response
 
           expect(Apia::OpenApi::Specification).to have_received(:new).with(
-            MockApi, base_url_option, name_option
+            MockApi, base_url_option, name_option, {}, {}
           )
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe Apia::OpenApi::Rack do
             )
 
             expect(Apia::OpenApi::Specification).to have_received(:new).with(
-              MockApi, default_base_url, name_option
+              MockApi, default_base_url, name_option, {}, {}
             )
           end
         end
@@ -151,7 +151,7 @@ RSpec.describe Apia::OpenApi::Rack do
           )
 
           expect(Apia::OpenApi::Specification).to have_received(:new).with(
-            api_class, default_base_url, name_option
+            api_class, default_base_url, name_option, {}, {}
           )
         end
       end

--- a/spec/apia/open_api/specification_spec.rb
+++ b/spec/apia/open_api/specification_spec.rb
@@ -12,23 +12,25 @@ RSpec.describe Apia::OpenApi::Specification do
       base_url = "http://127.0.0.1:9292/core/v1/"
       example_api = CoreAPI::Base
 
-      spec = described_class.new(example_api, base_url, "Core", {
-        version: "2.1.3",
-        contact: {
-          name: "API Support",
-          email: "support@example.com",
-          url: "https://example.com/support"
-        },
-        license: {
-          name: "Apache 2.0",
-          url: "https://www.apache.org/licenses/LICENSE-2.0.html"
-        },
-        termsOfService: "https://example.com/terms",
-        "x-added-info": "This is an example of adding custom information to the OpenAPI spec"
-      }, {
-                                     description: "Find out more",
-                                     url: "https://example.com"
-                                   })
+      spec = described_class.new(example_api, base_url, "Core",
+                                 {
+                                   version: "2.1.3",
+                                   contact: {
+                                     name: "API Support",
+                                     email: "support@example.com",
+                                     url: "https://example.com/support"
+                                   },
+                                   license: {
+                                     name: "Apache 2.0",
+                                     url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+                                   },
+                                   termsOfService: "https://example.com/terms",
+                                   "x-added-info": "This is an example of adding custom information to the OpenAPI spec"
+                                 },
+                                 {
+                                  description: "Find out more",
+                                  url: "https://example.com"
+                                 })
 
       # uncomment the following line for debugging :)
       # puts spec.json

--- a/spec/apia/open_api/specification_spec.rb
+++ b/spec/apia/open_api/specification_spec.rb
@@ -12,7 +12,23 @@ RSpec.describe Apia::OpenApi::Specification do
       base_url = "http://127.0.0.1:9292/core/v1/"
       example_api = CoreAPI::Base
 
-      spec = described_class.new(example_api, base_url, "Core")
+      spec = described_class.new(example_api, base_url, "Core", {
+        version: "2.1.3",
+        contact: {
+          name: "API Support",
+          email: "support@example.com",
+          url: "https://example.com/support"
+        },
+        license: {
+          name: "Apache 2.0",
+          url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        termsOfService: "https://example.com/terms",
+        "x-added-info": "This is an example of adding custom information to the OpenAPI spec"
+      }, {
+                                     description: "Find out more",
+                                     url: "https://example.com"
+                                   })
 
       # uncomment the following line for debugging :)
       # puts spec.json
@@ -27,7 +43,6 @@ RSpec.describe Apia::OpenApi::Specification do
     # confidence that the resulting JSON is valid according to OpenAPI.
     it "produces a valid spec" do
       spec = Openapi3Parser.load_file(fixture_path)
-
       expect(spec.errors).to be_empty
       expect(spec.valid?).to be true
     end

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -2,10 +2,6 @@
   "openapi": "3.0.0",
   "info": {
     "version": "2.1.3",
-    "externalDocs": {
-      "description": "Find out more",
-      "url": "https://example.com"
-    },
     "contact": {
       "name": "API Support",
       "email": "support@example.com",
@@ -19,6 +15,10 @@
     "x-added-info": "This is an example of adding custom information to the OpenAPI spec",
     "title": "Example API",
     "description": "Welcome to the documentation for the Example API"
+  },
+  "externalDocs": {
+    "description": "Find out more",
+    "url": "https://example.com"
   },
   "servers": [
     {

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -1,7 +1,22 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "version": "1.0.0",
+    "version": "2.1.3",
+    "externalDocs": {
+      "description": "Find out more",
+      "url": "https://example.com"
+    },
+    "contact": {
+      "name": "API Support",
+      "email": "support@example.com",
+      "url": "https://example.com/support"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "termsOfService": "https://example.com/terms",
+    "x-added-info": "This is an example of adding custom information to the OpenAPI spec",
     "title": "Example API",
     "description": "Welcome to the documentation for the Example API"
   },


### PR DESCRIPTION
Allows Passing of `info` and `external_docs` these will populate `info` and `externalDocs` in the openapi spec respectively.

All of the existing "generated" fields in info can be overridden.