### PR TITLE
fix: security schemes keys to symbols

### DIFF
--- a/lib/apia/open_api/specification.rb
+++ b/lib/apia/open_api/specification.rb
@@ -168,7 +168,7 @@ module Apia
       def add_additional_security_schemes(security_schemes)
         security_schemes.each do |key, value|
           @spec[:components][:securitySchemes] ||= {}
-          @spec[:components][:securitySchemes][key] = value
+          @spec[:components][:securitySchemes][key] = value.transform_keys(&:to_sym)
           @spec[:security] << { key => [] }
         end
       end


### PR DESCRIPTION
Looks up the x-scope-security value by either a string  or a symbol. 
Would appreciate if there's a better way to do this look up or enforce the key type in the hash.

## Edit
Rewritten to transform security scheme keys to symbols
