### PR TITLE
fix: don't insert `/` between prefix and scope, assume any prefix should contain it's own separator.

### DIFF
--- a/examples/config.ru
+++ b/examples/config.ru
@@ -44,7 +44,7 @@ use Apia::OpenApi::Rack,
     security_schemes: {
       OAuth2: {
         type: "oauth2",
-        "x-scope-prefix": "example.com/core/v1",
+        "x-scope-prefix": "example.com/core/v1/",
         flows: {
           authorizationCode: {
             authorizationUrl: "https://example.com/oauth/authorize",

--- a/lib/apia/open_api/objects/path.rb
+++ b/lib/apia/open_api/objects/path.rb
@@ -139,7 +139,7 @@ module Apia
             auth.each_key do |key|
               scopes = @route.endpoint.definition.scopes
               if scope_prefix = @spec[:components][:securitySchemes][key][:"x-scope-prefix"]
-                scopes = scopes.map { |v| "#{scope_prefix}/#{v}" }
+                scopes = scopes.map { |v| "#{scope_prefix}#{v}" }
               end
 
               @route_spec[:security] << { key => scopes }

--- a/spec/apia/open_api/specification_spec.rb
+++ b/spec/apia/open_api/specification_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Apia::OpenApi::Specification do
                                  security_schemes: {
                                   OAuth2: {
                                     type: "oauth2",
-                                    "x-scope-prefix": "example.com/core/v1",
+                                    "x-scope-prefix": "example.com/core/v1/",
                                     flows: {
                                       authorizationCode: {
                                         authorizationUrl: "https://example.com/oauth/authorize",

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -30,7 +30,7 @@
       "get": {
         "operationId": "get:time_formatting_incredibly_super_duper_long_format",
         "summary": "Format Time",
-        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Core"
         ],
@@ -110,7 +110,7 @@
       "post": {
         "operationId": "post:example_format",
         "summary": "Format Time",
-        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Core"
         ],
@@ -184,7 +184,7 @@
       "post": {
         "operationId": "post:example_format_multiple",
         "summary": "Format Multiple Times",
-        "description": "Format the given times\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Format the given times\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Core"
         ],
@@ -375,7 +375,7 @@
       "get": {
         "operationId": "get:t_f_i_s_d_l_f",
         "summary": "Format Time",
-        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Formatting"
         ],
@@ -455,7 +455,7 @@
       "post": {
         "operationId": "post:time_formatting_format",
         "summary": "Format Time",
-        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Format the given time\n## Scopes\n- `time`\n- `time:format`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Formatting"
         ],
@@ -529,7 +529,7 @@
       "get": {
         "operationId": "get:time_now",
         "summary": "Time Now Endpoint",
-        "description": "Returns the current time\n## Scopes\n- `time`\n- `time:now`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Returns the current time\n## Scopes\n- `time`\n- `time:now`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Time functions"
         ],
@@ -649,7 +649,7 @@
       "post": {
         "operationId": "post:time_now",
         "summary": "Time Now Endpoint",
-        "description": "Returns the current time\n## Scopes\n- `time`\n- `time:now`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Returns the current time\n## Scopes\n- `time`\n- `time:now`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Time functions"
         ],
@@ -768,7 +768,7 @@
       "get": {
         "operationId": "get:test_object",
         "summary": "Test Endpoint",
-        "description": "Returns the current time\n## Scopes\n- `time`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Returns the current time\n## Scopes\n- `time`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Time functions"
         ],
@@ -853,7 +853,7 @@
       "post": {
         "operationId": "post:test_object",
         "summary": "Test Endpoint",
-        "description": "Returns the current time\n## Scopes\n- `time`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1`.\n",
+        "description": "Returns the current time\n## Scopes\n- `time`\n\n### OAuth2 Scopes\nWhen using OAuth2 authentication, scopes are prefixed with `example.com/core/v1/`.\n",
         "tags": [
           "Time functions"
         ],
@@ -1466,7 +1466,7 @@
     "securitySchemes": {
       "OAuth2": {
         "type": "oauth2",
-        "x-scope-prefix": "example.com/core/v1",
+        "x-scope-prefix": "example.com/core/v1/",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://example.com/oauth/authorize",


### PR DESCRIPTION
Removes the insertion of a `/` between `x-scope-prefix` value and `scope` value. 

Prefixes should contain their own separator.