### PR TITLE
fix: only add mutually exclusive description to lookup argument sets

### DIFF
--- a/lib/apia/open_api/objects/parameters.rb
+++ b/lib/apia/open_api/objects/parameters.rb
@@ -146,6 +146,8 @@ module Apia
         end
 
         def add_lookup_description(description)
+          return unless @argument.type.klass.ancestors.include?(Apia::LookupArgumentSet)
+
           add_description_section(
             description,
             "All '#{@argument.name}[]' params are mutually exclusive, only one can be provided."

--- a/spec/support/fixtures/openapi.json
+++ b/spec/support/fixtures/openapi.json
@@ -279,7 +279,7 @@
                 "type": "string"
               }
             },
-            "description": "All 'disk_template_options[]' params are mutually exclusive, only one can be provided. \n\n All `disk_template_options[]` params should have the same amount of elements."
+            "description": "All `disk_template_options[]` params should have the same amount of elements."
           },
           {
             "in": "query",
@@ -290,7 +290,7 @@
                 "type": "string"
               }
             },
-            "description": "All 'disk_template_options[]' params are mutually exclusive, only one can be provided. \n\n All `disk_template_options[]` params should have the same amount of elements."
+            "description": "All `disk_template_options[]` params should have the same amount of elements."
           }
         ],
         "responses": {


### PR DESCRIPTION
I'd previously missed this check or I removed it at some point. 
I believe this behaviour is now correct and we only add the note about values being mutually exclusive on lookup argument sets.